### PR TITLE
Paleo mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ A paleography mode was added, in which sukūns, vowels and other diacritics are 
 The following new characters were also added: 
 | betacode | translit | Arabic letter |
 |----------|-----------------|-----------------------------|
-| **?b** | ɓ | *undotted b/t/th and non-final y/n* |
-| **?n** | ɲ| *undotted final n* |
-| **?f** | ƒ | *undotted fāʾ* |
-| **?q** | ɋ | *undotted qāf* |
-| **?o** | ° | *explicit sukūn* |
+| **?b** | ɓ | undotted *bāʾ/tāʾ/thāʾ* and non-final *yāʾ/nūn* |
+| **?n** | ɲ | undotted final *nūn* |
+| **?f** | ƒ | undotted *fāʾ* |
+| **?q** | ɋ | undotted *qāf* |
+| **?o** | ° | explicit *sukūn* |
 
 NB: no standard symbols appear to exist for transcribing undotted letters.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
-# Arabic betaCode
+﻿# Arabic betaCode
+
+
+## Paleography updates (2018-01-23)
+
+A paleography mode was added, in which sukūns, vowels and other diacritics are not automatically added in transcription and Arabic script, and users have the possibility to manually add sukūns. The betacodeToArabic and arabicToBetaCode functions now have an optional argument paleo that, if set to True, disables the automatic creation of sukūns and vowels apart from those that are explicitly transcribed. In paleo mode, use simple a or i at the beginning of a word to transcribe a bare alif without vowels, hamza, madda or waṣla. The default setting for paleo is False, so that the code is by default executed exactly as before.
+
+The following new characters were also added: 
+| betacode | translit | Arabic letter |
+|----------|-----------------|-----------------------------|
+| **?b** | ɓ | *undotted b/t/th and non-final y/n* |
+| **?n** | ɲ| *undotted final n* |
+| **?f** | ƒ | *undotted fāʾ* |
+| **?q** | ɋ | *undotted qāf* |
+| **?o** | ° | *explicit sukūn* |
+
+NB: no standard symbols appear to exist for transcribing undotted letters.
+
 
 ## Some updates to the scheme (2015-03-09:10-21)
 
@@ -6,6 +23,7 @@ Done to avoid issues with Alpheios translation alignment, which automatically sp
 
 * **=t** is *tāʾ marbūṭaŧ*
 * **\*s** is *ṣād* (and the same for other letters transliterated with dots)
+
 
 <center>[a better formatted version](http://maximromanov.github.io/2015/02-07.html)</center>
 
@@ -104,6 +122,8 @@ preceded (if necessary) with a technical character that is similar to a diacriti
 * silent *wāw* and *alif*:
 	* `*w` (`Amr?u*n*w`, for <span="arabic">عَمْرٌو</span>)
 	* `*a` (```wa-fa`al_u*a```, for <span="arabic">وَفَعَلُوا</span>)
+* bare initial alif (without vowels, hamza, wasla, madda): in paleo mode only:
+        * ```a``` or ```i``` 
 
 ## Running the converter
 * (Python 3.xx must be installed on the machine)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A paleography mode was added, in which sukūns, vowels and other diacritics are 
 
 The following new characters were also added: 
 | betacode | translit | Arabic letter |
-|----------|-----------------|-----------------------------|
+|----------|-----------------|---------------|
 | **?b** | ɓ | undotted *bāʾ/tāʾ/thāʾ* and non-final *yāʾ/nūn* |
 | **?n** | ɲ | undotted final *nūn* |
 | **?f** | ƒ | undotted *fāʾ* |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 A paleography mode was added, in which sukūns, vowels and other diacritics are not automatically added in transcription and Arabic script, and users have the possibility to manually add sukūns. The betacodeToArabic and arabicToBetaCode functions now have an optional argument paleo that, if set to True, disables the automatic creation of sukūns and vowels apart from those that are explicitly transcribed. In paleo mode, use simple a or i at the beginning of a word to transcribe a bare alif without vowels, hamza, madda or waṣla. The default setting for paleo is False, so that the code is by default executed exactly as before.
 
 The following new characters were also added: 
+
 | betacode | translit | Arabic letter |
 |----------|-----------------|---------------|
 | **?b** | ɓ | undotted *bāʾ/tāʾ/thāʾ* and non-final *yāʾ/nūn* |

--- a/betaCode.py
+++ b/betaCode.py
@@ -106,6 +106,8 @@ def betacodeToArabic(text, paleo=False):
     """
     
     cnsnnts = "btṯǧčḥḥḫdḏrzsšṣḍṭẓʿġfḳkglmnhwy"
+    if paleo:
+        cnsnnts += "ƒɋɲɓ" # placeholders for undotted letters f, q, n, b
     cnsnnts = "%s%s" % (cnsnnts, cnsnnts.upper())
 
     #print("betacodeToArabic()")
@@ -318,11 +320,11 @@ abn_a'u abn_a'i abn_a'a jar_i'u*n maqr_u'u*n *daw'u*n ^say'u*n juz'u*n
 """
 ##
 ###print(arabicToBetaCode(testStringArabic))
-print(betacodeToArabic(testBetaCode))
-print(betacodeToTranslit(testBetaCode))
-
-testtext = "آمن آمں ٮُبُرْس"
-testtext = arabicToBetaCode(testtext, paleo=True)
+testtext = "_amḥān _amm_u*n *bubur?os"
+testtext = betacodeToArabic(testtext, paleo=True)
+print(testtext)
+#testtext = "آمن آمں ٮُبُرْس"
+testtext = arabicToBetaCode(testtext, paleo=False)
 print(testtext)
 testtext = betacodeToArabic(testtext, paleo=True)
 print(testtext)

--- a/betaCode.py
+++ b/betaCode.py
@@ -86,7 +86,7 @@ def arabicToBetaCode(text, paleo=False):
 
     # fixing artifacts
     #text = re.sub(r"\b_a", r"a", text) # this also turns '_a into 'a
-    text = re.sub(r"(?<!')\b_a", r"a", text)
+    text = re.sub(r"(?<!')\b_a", r"a", text) # use negative lookbehind to exclude '_a
     text = re.sub(r"aa", r"a", text)
     text = re.sub(r"ii", r"i", text)
     text = re.sub(r"uu", r"u", text)
@@ -113,8 +113,7 @@ def betacodeToArabic(text, paleo=False):
 
     #print("betacodeToArabic()")
     text = dictReplace(text, betaCodeTables.betacodeTranslit)
-    if paleo:
-        text = re.sub('\?o' , '°', text)
+    text = re.sub('\?o' , '°', text)
     text = re.sub('\+' , '', text)
 
     # fix irrelevant variables for Arabic script
@@ -142,8 +141,15 @@ def betacodeToArabic(text, paleo=False):
 ##    text = re.sub("\\bʾ?i", "إِ", text)
 ##    text = re.sub("\\bʾ?u", "أُ", text)
 
-    text = re.sub("\\ba", "اَ", text)
-    text = re.sub("\\bi", "اِ", text)
+    
+    if not paleo:
+        text = re.sub("\\ba", "اَ", text)
+        text = re.sub("\\bi", "اِ", text)
+    else:
+        text = re.sub("\\baa", "اَ", text)
+        text = re.sub("\\bii", "اِ", text)
+        text = re.sub("\\b[ai]", "ا", text) # allow transcription of simple initial alif
+
     text = re.sub("\\bu", "اُ", text)
     
     text = re.sub("\\bʾa", "أَ", text)
@@ -321,10 +327,12 @@ abn_a'u abn_a'i abn_a'a jar_i'u*n maqr_u'u*n *daw'u*n ^say'u*n juz'u*n
 """
 ##
 ###print(arabicToBetaCode(testStringArabic))
-testtext = "_amḥān _amm_u*n *bubur?os"
+print(betacodeToArabic(testBetaCode))
+print(betacodeToTranslit(testBetaCode))
+testtext = "_amḥān iimm_u?n ?bubur?os"
 testtext = betacodeToArabic(testtext, paleo=True)
 print(testtext)
-#testtext = "آمن آمں ٮُبُرْس"
+#testtext = "امن آمں ٮُبُرْس"
 testtext = arabicToBetaCode(testtext, paleo=True)
 print(testtext)
 testtext = betacodeToArabic(testtext, paleo=True)

--- a/betaCode.py
+++ b/betaCode.py
@@ -98,12 +98,20 @@ def arabicToBetaCode(text, paleo=False):
     return(text)
 
 
-def betacodeToArabic(text):
+def betacodeToArabic(text, paleo=False):
+    """transcribe betacode to Arabic.
+    var paleo: if set to True:
+        - sukuns and vowels are only inserted when they are explicitly encoded
+        - dotless letters are added to the consonants
+    """
+    
     cnsnnts = "btṯǧčḥḥḫdḏrzsšṣḍṭẓʿġfḳkglmnhwy"
     cnsnnts = "%s%s" % (cnsnnts, cnsnnts.upper())
 
     #print("betacodeToArabic()")
     text = dictReplace(text, betaCodeTables.betacodeTranslit)
+    if paleo:
+        text = re.sub('\?o' , '°', text)
     text = re.sub('\+' , '', text)
 
     # fix irrelevant variables for Arabic script
@@ -235,15 +243,16 @@ def betacodeToArabic(text):
 
     # consonant combinations
     text = re.sub(r"([%s])\1" % cnsnnts, r"\1" + " ّ ".strip(), text)
-    # two consonants into C-sukun-C
-    text = re.sub(r"([%s])([%s])" % (cnsnnts,cnsnnts), r"\1%s\2" % " ْ ".strip(), text)
-    text = re.sub(r"([%s])([%s])" % (cnsnnts,cnsnnts), r"\1%s\2" % " ْ ".strip(), text)
-    # final consonant into C-sukun
-    text = re.sub(r"([%s])(\s|$)" % (cnsnnts), r"\1%s\2" % " ْ ".strip(), text)
-    # consonant + long vowel into C-shortV-longV
-    text = re.sub(r"([%s])(ā)" % (cnsnnts), r"\1%s\2" % " َ ".strip(), text)
-    text = re.sub(r"([%s])(ī)" % (cnsnnts), r"\1%s\2" % " ِ ".strip(), text)
-    text = re.sub(r"([%s])(ū)" % (cnsnnts), r"\1%s\2" % " ُ ".strip(), text)
+    if not paleo:
+        # two consonants into C-sukun-C
+        text = re.sub(r"([%s])([%s])" % (cnsnnts,cnsnnts), r"\1%s\2" % " ْ ".strip(), text)
+        text = re.sub(r"([%s])([%s])" % (cnsnnts,cnsnnts), r"\1%s\2" % " ْ ".strip(), text)
+        # final consonant into C-sukun
+        text = re.sub(r"([%s])(\s|$)" % (cnsnnts), r"\1%s\2" % " ْ ".strip(), text)
+        # consonant + long vowel into C-shortV-longV
+        text = re.sub(r"([%s])(ā)" % (cnsnnts), r"\1%s\2" % " َ ".strip(), text)
+        text = re.sub(r"([%s])(ī)" % (cnsnnts), r"\1%s\2" % " ِ ".strip(), text)
+        text = re.sub(r"([%s])(ū)" % (cnsnnts), r"\1%s\2" % " ُ ".strip(), text)
 
     # tanwins
     text = re.sub(r'([%s])aȵ' % "btṯǧḥḥḫdḏrzsšṣḍṭẓʿġfḳklmnhwy", r"\1%s" % 'اً', text)
@@ -314,4 +323,6 @@ print(betacodeToTranslit(testBetaCode))
 
 testtext = "آمن آمں ٮُبُرْس"
 testtext = arabicToBetaCode(testtext, paleo=True)
+print(testtext)
+testtext = betacodeToArabic(testtext, paleo=True)
 print(testtext)

--- a/betaCode.py
+++ b/betaCode.py
@@ -85,7 +85,8 @@ def arabicToBetaCode(text, paleo=False):
     text = re.sub(r"،", r",", text)
 
     # fixing artifacts
-    text = re.sub(r"\b_a", r"a", text)
+    #text = re.sub(r"\b_a", r"a", text) # this also turns '_a into 'a
+    text = re.sub(r"(?<!')\b_a", r"a", text)
     text = re.sub(r"aa", r"a", text)
     text = re.sub(r"ii", r"i", text)
     text = re.sub(r"uu", r"u", text)
@@ -324,7 +325,7 @@ testtext = "_amḥān _amm_u*n *bubur?os"
 testtext = betacodeToArabic(testtext, paleo=True)
 print(testtext)
 #testtext = "آمن آمں ٮُبُرْس"
-testtext = arabicToBetaCode(testtext, paleo=False)
+testtext = arabicToBetaCode(testtext, paleo=True)
 print(testtext)
 testtext = betacodeToArabic(testtext, paleo=True)
 print(testtext)

--- a/betaCode.py
+++ b/betaCode.py
@@ -67,7 +67,7 @@ def betacodeToLOC(text):
     text = re.sub(r"\w_", r"", text)
     return(text)
 
-def arabicToBetaCode(text):
+def arabicToBetaCode(text, paleo=False):
     #print("arabicToBetaCode()")
 
     # convert optative phrases    
@@ -78,7 +78,10 @@ def arabicToBetaCode(text):
     
     # converting tashdids and removing Arabic residue
     text = re.sub(r"(\w)%s" % " ّ ".strip(), r"\1\1", text)
-    text = re.sub(" ْ ".strip(), r"", text)
+    if not paleo:
+        text = re.sub(" ْ ".strip(), r"", text)
+    else: # keep explicit sukuns
+        text = re.sub(" ْ ".strip(), r"?o", text)
     text = re.sub(r"،", r",", text)
 
     # fixing artifacts
@@ -308,3 +311,7 @@ abn_a'u abn_a'i abn_a'a jar_i'u*n maqr_u'u*n *daw'u*n ^say'u*n juz'u*n
 ###print(arabicToBetaCode(testStringArabic))
 print(betacodeToArabic(testBetaCode))
 print(betacodeToTranslit(testBetaCode))
+
+testtext = "آمن آمں ٮُبُرْس"
+testtext = arabicToBetaCode(testtext, paleo=True)
+print(testtext)

--- a/betaCode.py
+++ b/betaCode.py
@@ -284,27 +284,27 @@ def betaCodeToArSimple(text):
 ##print(betacodeToLOC(testString))
 ##print(betacodeToArabic(testString))
 ##
-##testBetaCode = """
-##'amru.n 'unsu.n 'insu.n '_im_anu.n
-##'_aya:tu.n '_amana mas'ala:tu.n sa'ala ra'su.n qur'_anu.n ta'_amara
-##_di'bu.n as'ila:tu.n q_ari'i-hi su'lu.n mas'_ulu.n
-##tak_afu'u-hu su'ila q_ari'i-hi _di'_abu.n ra'_isu.n
-##bu'isa ru'_ufu.n ra'_ufu.n su'_alu.n mu'arri_hu.n
-##abn_a'a-hu abn_a'u-hu abn_a'i-hi ^say'a.n _ha.t_i'a:tu.n
-##.daw'u-hu .d_u'u-hu .daw'a-hu .daw'i-hi mur_u'a:tu.n
-##'abn_a'i-hi bar_i'u-hu s_u'ila f_ilu.n f_annu.n f_unnu.n
-##s_a'ala fu'_adu.n ^surak_a'u-hu ri'_asa:tu.n tahni'a:tu.n
-##daf_a'a:tu.n .taff_a'a:tu.n ta'r_i_hu.n fa'ru.n
-##^say'u.n ^say'i.n ^say'a.n  
-##.daw'u.n .daw'i.n .daw'a.n
-##juz'u.n  juz'i.n  juz'a.n
-##mabda'u.n mabda'i.n mabda'a.n
-##naba'a q_ari'u.n tak_afu'u.n tak_afu'i.n tak_afu'a.n
-##abn_a'u abn_a'i abn_a'a jar_i'u.n maqr_u'u.n .daw'u.n ^say'u.n juz'u.n
-##`ulam_a'u al-`ulam_a'i al-`ulam_a'a
-##`Amru.n.w wa-fa`al_u.a
-##"""
+testBetaCode = """
+'amru*n 'unsu*n 'insu*n '_im_anu*n
+'_aya=tu*n '_amana mas'ala=tu*n sa'ala ra'su*n qur'_anu*n ta'_amara
+_di'bu*n as'ila=tu*n q_ari'i-hi su'lu*n mas'_ulu*n
+tak_afu'u-hu su'ila q_ari'i-hi _di'_abu*n ra'_isu*n
+bu'isa ru'_ufu*n ra'_ufu*n su'_alu*n mu'arri_hu*n
+abn_a'a-hu abn_a'u-hu abn_a'i-hi ^say'a*n _ha*t_i'a=tu*n
+*daw'u-hu *d_u'u-hu *daw'a-hu *daw'i-hi mur_u'a=tu*n
+'abn_a'i-hi bar_i'u-hu s_u'ila f_ilu*n f_annu*n f_unnu*n
+s_a'ala fu'_adu*n ^surak_a'u-hu ri'_asa=tu*n tahni'a=tu*n
+daf_a'a:tu*n *taff_a'a=tu*n ta'r_i_hu*n fa'ru*n
+^say'u*n ^say'i*n ^say'a*n  
+*daw'u*n *daw'i*n *daw'a*n
+juz'u*n  juz'i*n  juz'a*n
+mabda'u*n mabda'i*n mabda'a*n
+naba'a q_ari'u*n tak_afu'u*n tak_afu'i*n tak_afu'a*n
+abn_a'u abn_a'i abn_a'a jar_i'u*n maqr_u'u*n *daw'u*n ^say'u*n juz'u*n
+`ulam_a'u al-`ulam_a'i al-`ulam_a'a
+`Amru*n*w wa-fa`al_u*a
+"""
 ##
 ###print(arabicToBetaCode(testStringArabic))
-##print(betacodeToArabic(testBetaCode))
-##print(betacodeToTranslit(testBetaCode))
+print(betacodeToArabic(testBetaCode))
+print(betacodeToTranslit(testBetaCode))

--- a/betaCodeTables.py
+++ b/betaCodeTables.py
@@ -70,7 +70,12 @@ betacodeTranslit = {
     #'_n' : 'ȵ',  # n of tanwīn
     '*n' : 'ȵ',   # n of tanwīn
     '*w' : 'ů',  # silent w, like in `Amru.n.w
-    '*a' : 'å'  # silent alif, like in fa`al_u.a    
+    '*a' : 'å',  # silent alif, like in fa`al_u.a    
+# Paleo: Dotless letters
+    "*b" :  "ɓ",   # dotless b/t/th and non-final nūn/yāʾ
+    "*q" :  "ɋ",   # dotless qāf
+    "*n" :  "ɲ",   # dotless final nūn
+    "*f" :  "ƒ",   # dotless fāʾ
     }
 
 # conventional US/LOC transliteration
@@ -232,6 +237,11 @@ translitArabic = {
     'ả' : ' َ ',  # final fatḥaŧ
     'ỉ' : ' ِ ',  # final ḍammaŧ
     'ủ' : ' ُ ',  # final kasraŧ 
+# Paleo: Dotless letters
+    "ɓ" : " ٮ",   # dotless b/t/th and non-final nūn/yāʾ
+    "ɋ" : " ٯ",   # dotless qāf
+    "ɲ" : " ں",   # dotless final nūn
+    "ƒ" : " ڡ",   # dotless fā
     }
 
 arabicBetaCode = {
@@ -282,4 +292,9 @@ arabicBetaCode = {
     " ً " :  "a*n", # tanwīn fatḥ
     " ٌ " :  "u*n", # tanwīn ḍamm
     " ٍ " :  "i*n", # tanwīn kasr
+# Paleo: Dotless letters
+    " ٮ" :  "*b",   # dotless b/t/th and non-final nūn/yāʾ
+    " ٯ" :  "*q",   # dotless qāf
+    " ں" :  "*n",   # dotless final nūn
+    " ڡ" :  "*f",   # dotless fāʾ
     }

--- a/betaCodeTables.py
+++ b/betaCodeTables.py
@@ -72,10 +72,10 @@ betacodeTranslit = {
     '*w' : 'ů',  # silent w, like in `Amru.n.w
     '*a' : 'å',  # silent alif, like in fa`al_u.a    
 # Paleo: Dotless letters
-    "*b" :  "ɓ",   # dotless b/t/th and non-final nūn/yāʾ
-    "*q" :  "ɋ",   # dotless qāf
-    "*n" :  "ɲ",   # dotless final nūn
-    "*f" :  "ƒ",   # dotless fāʾ
+    "?b" :  "ɓ",   # dotless b/t/th and non-final nūn/yāʾ
+    "?q" :  "ɋ",   # dotless qāf
+    "?n" :  "ɲ",   # dotless final nūn
+    "?f" :  "ƒ",   # dotless fāʾ
     }
 
 # conventional US/LOC transliteration
@@ -236,7 +236,9 @@ translitArabic = {
     'å' : ' ا ',  # silent alif, like in fa`al_u.a
     'ả' : ' َ ',  # final fatḥaŧ
     'ỉ' : ' ِ ',  # final ḍammaŧ
-    'ủ' : ' ُ ',  # final kasraŧ 
+    'ủ' : ' ُ ',  # final kasraŧ
+# Paleo: explicit sukūn
+    '°' : ' ْ ',  # explicit sukūn
 # Paleo: Dotless letters
     "ɓ" : " ٮ",   # dotless b/t/th and non-final nūn/yāʾ
     "ɋ" : " ٯ",   # dotless qāf
@@ -293,8 +295,8 @@ arabicBetaCode = {
     " ٌ " :  "u*n", # tanwīn ḍamm
     " ٍ " :  "i*n", # tanwīn kasr
 # Paleo: Dotless letters
-    " ٮ" :  "*b",   # dotless b/t/th and non-final nūn/yāʾ
-    " ٯ" :  "*q",   # dotless qāf
-    " ں" :  "*n",   # dotless final nūn
-    " ڡ" :  "*f",   # dotless fāʾ
+    " ٮ" :  "?b",   # dotless b/t/th and non-final nūn/yāʾ
+    " ٯ" :  "?q",   # dotless qāf
+    " ں" :  "?n",   # dotless final nūn
+    " ڡ" :  "?f",   # dotless fāʾ
     }


### PR DESCRIPTION
I'm experimenting with using ArabicBetacode for transcribing manuscripts. The idea is to write the transcription in ArabicBetacode, which should make it easier to add tags without switching keyboard layouts, and then have the ArabicBetacode converted into Arabic characters. 
However, the normal mode of betacodeToArabic adds sukūns, vowels and other diacritics that were not in the ArabicBetacode transcription.
For this reason, I have added an optional argument "paleo" to the betacodeToArabic and arabicToBetaCode functions that, if set to True, disables the automatic creation of sukūns and vowels apart from those that were explicitly transcribed. Additionally, in paleo mode, one can use simple a or i at the beginning of a word to transcribe a bare alif without vowels, hamza, madda or waṣla; and sukūns can be manually added. 
The default setting for paleo is False, so that the code is by default executed exactly as before.

I also added a number of extra characters for dotless, i.e., defectively written b/t/th (and non-final y/n), final nūn, fā' and qāf; and for sukūn. The latter is transcribed only in paleo mode, the other new characters are available both in paleo and normal mode.  

Finally, I fixed a bug in the transcription of initial alif-madda. 