### PR TITLE
Persian support + streamlining tanwīn rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 ﻿# Arabic betaCode
 
 
-## Paleography updates and Persian support(2018-01-27)
+
+
+## Support for OpenITI mARkdown(2018-01-27)
+
+Texts with OpenITI mARkdown tags (https://maximromanov.github.io/mARkdown/) can now be converted without having effect on the tags. All conversion functions now have an optional `mARkdown` argument (default: `False`); if set to `True`, the tags will be temporarily replaced by placeholders and put back into the text after conversion.
+
+
+## Paleography updates and Persian support (2018-01-27)
 
 A paleography mode was added, in which sukūns, vowels and other diacritics are not automatically added in transcription and Arabic script, and users have the possibility to manually add sukūns. The `betacodeToArabic` and `arabicToBetaCode` functions now have an optional argument `paleo` that, if set to `True`, disables the automatic creation of sukūns and vowels apart from those that are explicitly transcribed. In `paleo` mode, use simple a or i at the beginning of a word to transcribe a bare alif without vowels, hamza, madda or waṣla. The default setting for `paleo` is `False`, so that the code is by default executed exactly as before.
 In addition, support for Persian was added. Persian letters are transcribed in normal mode. In addition, the `betacodeToArabic` and `betaCodeToArSimple` functions now have an optional argument `persian` (default: `False`); if set to `True`, the Persian variants of *kāf* and *yā'* will be used instead of the Arabic versions (which look slightly different, and have different Unicode code points) will be used in the output. More functionality may be added later.

--- a/README.md
+++ b/README.md
@@ -154,29 +154,29 @@ preceded (if necessary) with a technical character that is similar to a diacriti
 
 **NB**: These are examples of converting betaCode to full transliteration and Arabic script. The very last paragraph showcases conversion of *hamzaŧ* in different positions.
 
-q\_ala 'ab\_u Mas\`\_ud?i.n :: 'an\_a qad sami\`tu h~a\_d\_a min ras\_ul?i All~ah?i ( .sl\`m )
+q\_ala 'ab\_u Mas\`\_ud?i*n :: 'an\_a qad sami\`tu h~a\_d\_a min ras\_ul?i All~ah?i ( *sl\`m )
 
-.hadda\_ta-n\_a \`Amr?u.w bn?u R\_afi\`?i.n , .hadda\_ta-n\_a \`Abd?u All~ah?i bn?u al-Mub\_arak?i , \`an Mu.hammad?i bn?i 'Is.h\_aq?a , \`an Mu.hammad?i bn?i ^Ga\`far?i.n , \`an \`Ubayd?i All~ah?i bn?i \`Abd?i All~ah?i bn?i \`Umar?a , \`an 'Ab\_i-hi , \`an?i al-Nabiyy?i ( .sl\`m ) na.hwa-hu
+*hadda\_ta-n\_a \`Amr?u*w bn?u R\_afi\`?i*n , *hadda\_ta-n\_a \`Abd?u All~ah?i bn?u al-Mub\_arak?i , \`an Mu*hammad?i bn?i 'Is*h\_aq?a , \`an Mu*hammad?i bn?i ^Ga\`far?i*n , \`an \`Ubayd?i All~ah?i bn?i \`Abd?i All~ah?i bn?i \`Umar?a , \`an 'Ab\_i-hi , \`an?i al-Nabiyy?i ( *sl\`m ) na*hwa-hu
 
-'a\_hbara-n\_a Qutayba:t?u q\_ala , .hadda\_ta-n\_a Sufy\_an?u , \`an Ya.hy/a bn?i Sa\`\_id?i.n , \`an 'Ab\_i Bakr?i bn?i Mu.hammad?i.n , \`an \`Umar?a bn?i \`Abd?i al-\`Az\_iz?i , \`an 'Ab\_i Bakr?i bn?i \`Abd?i al-Ra.hm~an?i bn?i al-.H\_ari\_t?i bn?i Hi^s\_am?i.n , \`an 'Ab\_i Hurayra:t?a mi\_tla-hu
+'a\_hbara-n\_a Qutayba=t?u q\_ala , *hadda\_ta-n\_a Sufy\_an?u , \`an Ya*hy/a bn?i Sa\`\_id?i*n , \`an 'Ab\_i Bakr?i bn?i Mu*hammad?i*n , \`an \`Umar?a bn?i \`Abd?i al-\`Az\_iz?i , \`an 'Ab\_i Bakr?i bn?i \`Abd?i al-Ra*hm~an?i bn?i al-*H\_ari\_t?i bn?i Hi^s\_am?i*n , \`an 'Ab\_i Hurayra=t?a mi\_tla-hu
 
-**Ta.hw\_il?u al-hamza:t?i ( kalim\_at?u.n mufrada:t?u.n )**
+**Ta*hw\_il?u al-hamza=t?i ( kalim\_at?u*n mufrada=t?u*n )**
 
-'amr?u.n 'uns?u.n 'ins?u.n '\_im\_an?u.n
-'\_aya:t?u.n '\_amana mas'ala:t?u.n sa'ala ra's?u.n qur'\_an?u.n ta'\_amara
-\_di'b?u.n as'ila:t?u.n q\_ari'i-hi su'l?u.n mas'\_ul?u.n
-tak\_afu'u-hu su'ila q\_ari'i-hi \_di'\_ab?u.n ra'\_is?u.n
-bu'isa ru'\_uf?u.n ra'\_uf?u.n su'\_al?u.n mu'arri\_h?u.n
-abn\_a'a-hu abn\_a'u-hu abn\_a'i-hi ^say'?a.n \_ha.t\_i'a:t?u.n
-.daw'u-hu .d\_u'u-hu .daw'a-hu .daw'i-hi mur\_u'a:t?u.n
-'abn\_a'i-hi bar\_i'u-hu s\_u'ila f\_il?u.n f\_ann?u.n f\_unn?u.n
-s\_a'ala fu'\_ad?u.n ^surak\_a'u-hu ri'\_asa:t?u.n tahni'a:t?u.n
-daf\_a'a:t?u.n .taff\_a'a:t?u.n ta'r\_i\_h?u.n fa'r?u.n
-^say'?u.n ^say'?i.n ^say'?a.n  .daw'?u.n .daw'?i.n .daw'?a.n
-juz'?u.n  juz'?i.n  juz'?a.n mabda'?u.n mabda'?i.n mabda'?a.n
-naba'a q\_ari'?u.n tak\_afu'?u.n tak\_afu'?i.n tak\_afu'?a.n
-abn\_a'u abn\_a'i abn\_a'a jar\_i'?u.n maqr\_u'?u.n .daw'?u.n ^say'?u.n juz'?u.n
-\`ulam\_a'u al-\`ulam\_a'i al-\`ulam\_a'a \`Amr?u.n.w wa-fa\`al\_u.a
+'amr?u*n 'uns?u*n 'ins?u*n '\_im\_an?u*n
+'\_aya=t?u*n '\_amana mas'ala=t?u*n sa'ala ra's?u*n qur'\_an?u*n ta'\_amara
+\_di'b?u*n as'ila=t?u*n q\_ari'i-hi su'l?u*n mas'\_ul?u*n
+tak\_afu'u-hu su'ila q\_ari'i-hi \_di'\_ab?u*n ra'\_is?u*n
+bu'isa ru'\_uf?u*n ra'\_uf?u*n su'\_al?u*n mu'arri\_h?u*n
+abn\_a'a-hu abn\_a'u-hu abn\_a'i-hi ^say'?a*n \_ha*t\_i'a=t?u*n
+*daw'u-hu *d\_u'u-hu *daw'a-hu *daw'i-hi mur\_u'a=t?u*n
+'abn\_a'i-hi bar\_i'u-hu s\_u'ila f\_il?u*n f\_ann?u*n f\_unn?u*n
+s\_a'ala fu'\_ad?u*n ^surak\_a'u-hu ri'\_asa=t?u*n tahni'a=t?u*n
+daf\_a'a=t?u*n *taff\_a'a=t?u*n ta'r\_i\_h?u*n fa'r?u*n
+^say'?u*n ^say'?i*n ^say'?a*n  *daw'?u*n *daw'?i*n *daw'?a*n
+juz'?u*n  juz'?i*n  juz'?a*n mabda'?u*n mabda'?i*n mabda'?a*n
+naba'a q\_ari'?u*n tak\_afu'?u*n tak\_afu'?i*n tak\_afu'?a*n
+abn\_a'u abn\_a'i abn\_a'a jar\_i'?u*n maqr\_u'?u*n *daw'?u*n ^say'?u*n juz'?u*n
+\`ulam\_a'u al-\`ulam\_a'i al-\`ulam\_a'a \`Amr?u*n*w wa-fa\`al\_u*a
 
 ## betaCode converted into one-to-one translit
 
@@ -248,7 +248,7 @@ NB: This is an example of the English text with terms, names and toponyms given 
 
 Dima^s.k, Dima^s.k al-^S\_am or simply al-^S\_am , (Lat. Damascus, Fr. Damas) is the largest city of Syria. It is situated ... very much at the same latitude as Ba.gd\_ad and F\_as, at an altitude of nearly 700 metres, on the edge of the desert at the foot of ^Gabal .K\_asiy\_un.
 
-al-\_Dahab\_i, ^Sams al-D\_in Ab\_u \`Abd All~ah Mu.hammad b. \`U\_tm\_an b. .K\_aym\_a.z b. \`Abd All~ah al-Turkum\_an\_i al-F\_ari.k\_i al-Dima^s.k\_i al-^S\_afi\`\_i, an Arab historian and theologian, was born at Damascus or at Mayy\_afari.k\_in on 1 or 3 Rab\_i\` II (according to al-Kutub\_i, in Rab\_i\` I) 673/5 or 7 October 1274, and died at Damascus, according to al-Subk\_i and al-Suy\_u.t\_i, in the night of Sunday-Monday on 3 \_D\_u al-.Ka\`da:t 748/4 February 1348, or, according to A.hmad b. \`Iy\_as, in 753/1352-3. He was buried at the B\_ab al-.Sa.g\_ir.
+al-\_Dahab\_i, ^Sams al-D\_in Ab\_u \`Abd All~ah Mu.hammad b. \`U\_tm\_an b. .K\_aym\_a.z b. \`Abd All~ah al-Turkum\_an\_i al-F\_ari.k\_i al-Dima^s.k\_i al-^S\_afi\`\_i, an Arab historian and theologian, was born at Damascus or at Mayy\_afari.k\_in on 1 or 3 Rab\_i\` II (according to al-Kutub\_i, in Rab\_i\` I) 673/5 or 7 October 1274, and died at Damascus, according to al-Subk\_i and al-Suy\_u.t\_i, in the night of Sunday-Monday on 3 \_D\_u al-.Ka\`da=t 748/4 February 1348, or, according to A.hmad b. \`Iy\_as, in 753/1352-3. He was buried at the B\_ab al-.Sa.g\_ir.
 
 ### betaCode converted into one-to-one translit
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,28 @@
 ﻿# Arabic betaCode
 
 
-## Paleography updates (2018-01-23)
+## Paleography updates and Persian support(2018-01-27)
 
-A paleography mode was added, in which sukūns, vowels and other diacritics are not automatically added in transcription and Arabic script, and users have the possibility to manually add sukūns. The betacodeToArabic and arabicToBetaCode functions now have an optional argument paleo that, if set to True, disables the automatic creation of sukūns and vowels apart from those that are explicitly transcribed. In paleo mode, use simple a or i at the beginning of a word to transcribe a bare alif without vowels, hamza, madda or waṣla. The default setting for paleo is False, so that the code is by default executed exactly as before.
+A paleography mode was added, in which sukūns, vowels and other diacritics are not automatically added in transcription and Arabic script, and users have the possibility to manually add sukūns. The `betacodeToArabic` and `arabicToBetaCode` functions now have an optional argument `paleo` that, if set to `True`, disables the automatic creation of sukūns and vowels apart from those that are explicitly transcribed. In `paleo` mode, use simple a or i at the beginning of a word to transcribe a bare alif without vowels, hamza, madda or waṣla. The default setting for `paleo` is `False`, so that the code is by default executed exactly as before.
+In addition, support for Persian was added. Persian letters are transcribed in normal mode. In addition, the `betacodeToArabic` and `betaCodeToArSimple` functions now have an optional argument `persian` (default: `False`); if set to `True`, the Persian variants of *kāf* and *yā'* will be used instead of the Arabic versions (which look slightly different, and have different Unicode code points) will be used in the output. More functionality may be added later.
 
 The following new characters were also added: 
 
 | betacode | translit | Arabic letter |
 |----------|-----------------|---------------|
-| **?b** | ɓ | undotted *bāʾ/tāʾ/thāʾ* and non-final *yāʾ/nūn* |
-| **?n** | ɲ | undotted final *nūn* |
-| **?f** | ƒ | undotted *fāʾ* |
-| **?q** | ɋ | undotted *qāf* |
-| **?o** | ° | explicit *sukūn* |
+| **?b** | ɓ \* | undotted *bāʾ/tāʾ/thāʾ* and non-final *yāʾ/nūn* |
+| **?n** | ɲ \* | undotted final *nūn* |
+| **?f** | ƒ \* | undotted *fāʾ* |
+| **?q** | ɋ \* | undotted *qāf* |
+| **!o** | ° | explicit *sukūn* (paleo mode) |
+| **p** | p | Persian letter *pe* |
+| **^c** | č | Persian letter *che* |
+| **^z** | ž | Persian letter *zhe* |
+| **k** | k | Persian letter *kāf* \*\* |
+| **g** | g | Persian letter *gāf* |
 
-NB: no standard symbols appear to exist for transcribing undotted letters.
+\* no standard symbols appear to exist for transcribing undotted letters.
+\*\* Persian and Arabic *kāf* are transcribed in the same way; the `persian` argument in the `betacodeToArabic` function defines if the Persian or Arabic variant is used in the output.
 
 
 ## Some updates to the scheme (2015-03-09:10-21)
@@ -44,15 +51,18 @@ Done to avoid issues with Alpheios translation alignment, which automatically sp
 |----------|-----------------|---------------|
 | **\_a** | ā | *alif* |
 | **b** | b | *bāʾ* |
+| **p** | p | Persian letter *pe* |
 | **t** | t | *tāʾ* |
 | **\_t** | ṯ | *thāʾ* |
 | **^g, j** | ǧ | *jīm* |
+| **^c** | č | Persian letter *che* |
 | **\*h** | ḥ | *ḥāʾ* |
 | **\_h** | ḫ | *khāʾ* |
 | **d** | d | *dāl* |
 | **\_d** | ḏ | *dhāl* |
 | **r** | r | *rā’* |
 | **z** | z | *zayn* |
+| **^z** | ž | Persian letter *zhe* |
 | **s** | s | *sīn* |
 | **^s** | š | *shīn* |
 | **\*s** | ṣ | *ṣād* |
@@ -63,7 +73,8 @@ Done to avoid issues with Alpheios translation alignment, which automatically sp
 | **\*g** | ġ | *ghayn* |
 | **f** | f | *fāʾ* |
 | **\*k, q** | ḳ | *qāf* |
-| **k** | k | *kāf* |
+| **k** | k | *kāf* (Arabic and Persian) |
+| **g** | g | Persian letter *gāf* |
 | **l** | l | *lām* |
 | **m** | m | *mīm* |
 | **n** | n | *nūn* |
@@ -88,6 +99,7 @@ Done to avoid issues with Alpheios translation alignment, which automatically sp
 | **u** | u | *ḍammaŧ* |
 | **i** | i | *kasraŧ* |
 | **a** | a | *fatḥaŧ* |
+| **!o** | ° | explicit *sukūn* (paleo mode) |
 | **\*n** | ȵ | *n* of *tanwīn* |
 | **\*a** | å | *silent alif* |
 | **\*w** | ů | *silent wāw* |
@@ -105,6 +117,7 @@ preceded (if necessary) with a technical character that is similar to a diacriti
 * **\_** (underscore), if a letter can be transliterated with *macron*/*breve* below or above (*ā*, *ṯ*, *ḫ*, *ḏ*, *ū*, *ī*)
 * **\*** (asterisk), if a letter can be transliterated transliterated with *dot* below or above (*ḥ*, *ṣ*, *ḍ*, *ṭ*, *ẓ*, *ġ*, *ḳ*)
 * **^** (caret), if a letter can be transliterated with *caron* (*ǧ*, *š*)
+* **!** (exclamation mark), for diacritics that are explicitly in a manuscript (in paleo mode only)
 
 #### *Specifics*
 * attached prepositions/conjunctions and pronominal suffixes must be separated with “-” (mostly relevant for text alignment, treebanking,  and general readability):
@@ -113,8 +126,8 @@ preceded (if necessary) with a technical character that is similar to a diacriti
 	* ``` bi-Llah?i  ```, but not:
 	* ``` fa-_dahaba ```	
 * *tāʾ marbūṭaŧ*: add “+” after *tāʾ marbūṭaŧ*, if the first word of *iḏāfaŧ* (mostly relevant for transliteration):
-	* ``` `_amma:t+u Ba.gd_ada ```, but:
-	* ``` al-`_amma:tu f_i Ba.gd_ada ```
+	* ``` `_amma=t+u Ba.gd_ada ```, but:
+	* ``` al-`_amma=tu f_i Ba.gd_ada ```
 * transliterating *tanwīn*:
 	* ```*n```
 		* ```?u*n```

--- a/betaCode.py
+++ b/betaCode.py
@@ -28,9 +28,13 @@ def deNoise(text):
 
 # define replacement with dictionaries
 def dictReplace(text, dic):
+    tup_list = []
     for k, v in dic.items():
         k = k.strip()
         v = v.strip()
+        tup_list.append((k,v))
+    # replace the longest elements first:
+    for k,v in sorted(tup_list, key=lambda x: len(x[0]), reverse=True):
         text = text.replace(k, v)
         if len(v) > 1:
             vUpper = v[0].upper()+v[1:]
@@ -67,21 +71,24 @@ def betacodeToLOC(text):
     text = re.sub(r"\w_", r"", text)
     return(text)
 
-def arabicToBetaCode(text, paleo=False):
+def arabicToBetaCode(text, paleo=False, persian=False):
     #print("arabicToBetaCode()")
 
     # convert optative phrases    
     text = re.sub(r"صلى الله عليه وسلم", r".sl`m", text)
     text = re.sub(r"radiyallahuanhu", r"r.dh", text)
 
-    text = dictReplace(text, betaCodeTables.arabicBetaCode)
-    
-    # converting tashdids and removing Arabic residue
-    text = re.sub(r"(\w)%s" % " ّ ".strip(), r"\1\1", text)
+    # deal with sukun
     if not paleo:
         text = re.sub(" ْ ".strip(), r"", text)
     else: # keep explicit sukuns
         text = re.sub(" ْ ".strip(), r"?o", text)
+
+    # replace all letters
+    text = dictReplace(text, betaCodeTables.arabicBetaCode)
+    
+    # converting tashdids and removing Arabic residue
+    text = re.sub(r"(\w)%s" % " ّ ".strip(), r"\1\1", text)
     text = re.sub(r"،", r",", text)
 
     # fixing artifacts
@@ -90,6 +97,8 @@ def arabicToBetaCode(text, paleo=False):
     text = re.sub(r"aa", r"a", text)
     text = re.sub(r"ii", r"i", text)
     text = re.sub(r"uu", r"u", text)
+##    text = re.sub(r"([uia])\*n", r"?\1*n", text)
+    text = re.sub(r"'au", r"'u", text)
     text = re.sub(r"a_a", r"_a", text)
     text = re.sub(r"a/a", r"/a", text)
     text = re.sub(r"iy", r"_i", text)
@@ -99,7 +108,7 @@ def arabicToBetaCode(text, paleo=False):
     return(text)
 
 
-def betacodeToArabic(text, paleo=False):
+def betacodeToArabic(text, paleo=False, persian=False):
     """transcribe betacode to Arabic.
     var paleo: if set to True:
         - sukuns and vowels are only inserted when they are explicitly encoded
@@ -118,9 +127,9 @@ def betacodeToArabic(text, paleo=False):
 
     # fix irrelevant variables for Arabic script
     text = text.lower()
-    text = re.sub("ủ", "u", text)
-    text = re.sub("ỉ", "i", text)
-    text = re.sub("ả", "a", text)
+##    text = re.sub("ủ", "u", text)
+##    text = re.sub("ỉ", "i", text)
+##    text = re.sub("ả", "a", text)
     
     # complex combinations
     sun = "tṯdḏrzsšṣḍṭẓln"
@@ -165,35 +174,35 @@ def betacodeToArabic(text, paleo=False):
     # final HAMZAs
     text = re.sub(r'yʾaȵ', r"يْئًا", text)
     
-    text = re.sub(r'([%s])ʾuȵ' % cnsnnts, r"\1%s" % "ْءٌ", text)
-    text = re.sub(r'([%s])ʾiȵ' % cnsnnts, r"\1%s" % "ْءٍ", text)
-    text = re.sub(r'([%s])ʾaȵ' % cnsnnts, r"\1%s" % "ْءًا", text)
+    text = re.sub(r'([%s])ʾủȵ' % cnsnnts, r"\1%s" % "ْءٌ", text)
+    text = re.sub(r'([%s])ʾỉȵ' % cnsnnts, r"\1%s" % "ْءٍ", text)
+    text = re.sub(r'([%s])ʾảȵ' % cnsnnts, r"\1%s" % "ْءًا", text)
 
     # short, hamza, tanwin
-    text = re.sub(r'uʾuȵ', r"ُؤٌ", text)
-    text = re.sub(r'uʾiȵ', r"ُؤٍ", text)
-    text = re.sub(r'uʾaȵ', r"ُؤًا", text)
+    text = re.sub(r'uʾủȵ', r"ُؤٌ", text)
+    text = re.sub(r'uʾỉȵ', r"ُؤٍ", text)
+    text = re.sub(r'uʾảȵ', r"ُؤًا", text)
 
-    text = re.sub(r'iʾuȵ', r"ِئٌ", text)
-    text = re.sub(r'iʾiȵ', r"ِئٍ", text)
-    text = re.sub(r'iʾaȵ', r"ِئًا", text)
+    text = re.sub(r'iʾủȵ', r"ِئٌ", text)
+    text = re.sub(r'iʾỉȵ', r"ِئٍ", text)
+    text = re.sub(r'iʾảȵ', r"ِئًا", text)
 
-    text = re.sub(r'aʾuȵ', r"َأٌ", text)
-    text = re.sub(r'aʾiȵ', r"َأٍ", text)
-    text = re.sub(r'aʾaȵ', r"َأً", text)
+    text = re.sub(r'aʾủȵ', r"َأٌ", text)
+    text = re.sub(r'aʾỉȵ', r"َأٍ", text)
+    text = re.sub(r'aʾảȵ', r"َأً", text)
 
     # long, hamza, tanwin
-    text = re.sub(r'ūʾuȵ', r"وءٌ", text)
-    text = re.sub(r'ūʾiȵ', r"وءٍ", text)
-    text = re.sub(r'ūʾaȵ', r"وءً", text)
+    text = re.sub(r'ūʾủȵ', r"وءٌ", text)
+    text = re.sub(r'ūʾỉȵ', r"وءٍ", text)
+    text = re.sub(r'ūʾảȵ', r"وءً", text)
 
-    text = re.sub(r'īʾuȵ', r"يءٌ", text)
-    text = re.sub(r'īʾiȵ', r"يءٍ", text)
-    text = re.sub(r'īʾaȵ', r"يءً", text)
+    text = re.sub(r'īʾủȵ', r"يءٌ", text)
+    text = re.sub(r'īʾỉȵ', r"يءٍ", text)
+    text = re.sub(r'īʾảȵ', r"يءً", text)
 
-    text = re.sub(r'āʾuȵ', r"اءٌ", text)
-    text = re.sub(r'āʾiȵ', r"اءٍ", text)
-    text = re.sub(r'āʾaȵ', r"اءً", text)
+    text = re.sub(r'āʾủȵ', r"اءٌ", text)
+    text = re.sub(r'āʾỉȵ', r"اءٍ", text)
+    text = re.sub(r'āʾảȵ', r"اءً", text)
 
     # long, hamza, diptote
     text = re.sub(r'āʾu\b', r"اءُ", text)
@@ -274,13 +283,18 @@ def betacodeToArabic(text, paleo=False):
     text = re.sub('å' , "ا", text)
 
 
+    if persian:
+        betaCodeTables.translitArabic["k"] = "ک"
+        betaCodeTables.translitArabic["y"] = "ی"
+        betaCodeTables.translitArabic["ī"] = "ی"
+    
     text = dictReplace(text, betaCodeTables.translitArabic)
     text = re.sub("-|_", "", text)
     #text = re.sub("-", "ـ ـ", text)
     return(text)
 
-def betaCodeToArSimple(text):
-    text = betacodeToArabic(text)
+def betaCodeToArSimple(text, paleo=False, persian=False):
+    text = betacodeToArabic(text, paleo, persian)
     text = deNoise(text)
     return(text)
     
@@ -288,52 +302,63 @@ def betaCodeToArSimple(text):
 ###########################################################
 # BELOW : TESTING ZONE ####################################
 ###########################################################
-##
-##testString = """
-##.kul huwa all~ahu_ a.hadu.n all~ahu_ al-.samadu_ lam yalid wa-lam y_ulad wa-lam yakun lahu kufu'a.n a.hadu.n
-##
-##wa-.k_amat `_amma:t+u_ Ba.gd_ada_ li-yusallima al-_hal_ifa:ta_ al-Man.s_ura_ `al/a ruj_u`i-hi min al-K_ufa:ti_
-##
-##al-.hamdu li-Ll~ahi rabbi al-`_alam_ina_
-##"""
-##
-##
-####print("betacode")
-####print(testString)
-##print(betacodeToTranslit(testString))
-##print(betacodeToSearch(testString))
-##print(betacodeToLOC(testString))
-##print(betacodeToArabic(testString))
-##
-testBetaCode = """
-'amru*n 'unsu*n 'insu*n '_im_anu*n
-'_aya=tu*n '_amana mas'ala=tu*n sa'ala ra'su*n qur'_anu*n ta'_amara
-_di'bu*n as'ila=tu*n q_ari'i-hi su'lu*n mas'_ulu*n
-tak_afu'u-hu su'ila q_ari'i-hi _di'_abu*n ra'_isu*n
-bu'isa ru'_ufu*n ra'_ufu*n su'_alu*n mu'arri_hu*n
-abn_a'a-hu abn_a'u-hu abn_a'i-hi ^say'a*n _ha*t_i'a=tu*n
-*daw'u-hu *d_u'u-hu *daw'a-hu *daw'i-hi mur_u'a=tu*n
-'abn_a'i-hi bar_i'u-hu s_u'ila f_ilu*n f_annu*n f_unnu*n
-s_a'ala fu'_adu*n ^surak_a'u-hu ri'_asa=tu*n tahni'a=tu*n
-daf_a'a:tu*n *taff_a'a=tu*n ta'r_i_hu*n fa'ru*n
-^say'u*n ^say'i*n ^say'a*n  
-*daw'u*n *daw'i*n *daw'a*n
-juz'u*n  juz'i*n  juz'a*n
-mabda'u*n mabda'i*n mabda'a*n
-naba'a q_ari'u*n tak_afu'u*n tak_afu'i*n tak_afu'a*n
-abn_a'u abn_a'i abn_a'a jar_i'u*n maqr_u'u*n *daw'u*n ^say'u*n juz'u*n
-`ulam_a'u al-`ulam_a'i al-`ulam_a'a
-`Amru*n*w wa-fa`al_u*a
-"""
-##
-###print(arabicToBetaCode(testStringArabic))
-print(betacodeToArabic(testBetaCode))
-print(betacodeToTranslit(testBetaCode))
-testtext = "_amḥān iimm_u?n ?bubur?os"
-testtext = betacodeToArabic(testtext, paleo=True)
-print(testtext)
-#testtext = "امن آمں ٮُبُرْس"
-testtext = arabicToBetaCode(testtext, paleo=True)
-print(testtext)
-testtext = betacodeToArabic(testtext, paleo=True)
-print(testtext)
+
+if __name__ == "__main__":
+    ##
+    ##testString = """
+    ##.kul huwa all~ahu_ a.hadu.n all~ahu_ al-.samadu_ lam yalid wa-lam y_ulad wa-lam yakun lahu kufu'a.n a.hadu.n
+    ##
+    ##wa-.k_amat `_amma:t+u_ Ba.gd_ada_ li-yusallima al-_hal_ifa:ta_ al-Man.s_ura_ `al/a ruj_u`i-hi min al-K_ufa:ti_
+    ##
+    ##al-.hamdu li-Ll~ahi rabbi al-`_alam_ina_
+    ##"""
+    ##
+    ##
+    ####print("betacode")
+    ####print(testString)
+    ##print(betacodeToTranslit(testString))
+    ##print(betacodeToSearch(testString))
+    ##print(betacodeToLOC(testString))
+    ##print(betacodeToArabic(testString))
+    ##
+    testBetaCode = """
+    'amr?u*n 'uns?u*n 'ins?u*n '_im_an?u*n
+    '_aya=t?u*n '_amana mas'ala=t?u*n sa'ala ra's?u*n qur'_an?u*n ta'_amara
+    _di'b?u*n as'ila=t?u*n q_ari'i-hi su'l?u*n mas'_ul?u*n
+    tak_afu'u-hu su'ila q_ari'i-hi _di'_ab?u*n ra'_is?u*n
+    bu'isa ru'_uf?u*n ra'_uf?u*n su'_al?u*n mu'arri_h?u*n
+    abn_a'a-hu abn_a'u-hu abn_a'i-hi ^say'a*n _ha*t_i'a=t?u*n
+    *daw'u-hu *d_u'u-hu *daw'a-hu *daw'i-hi mur_u'a=t?u*n
+    'abn_a'i-hi bar_i'u-hu s_u'ila f_il?u*n f_ann?u*n f_unn?u*n
+    s_a'ala fu'_ad?u*n ^surak_a'u-hu ri'_asa=t?u*n tahni'a=t?u*n
+    daf_a'a=t?u*n *taff_a'a=t?u*n ta'r_i_h?u*n fa'r?u*n
+    ^say'?u*n ^say'?i*n ^say'?a*n  
+    *daw'?u*n *daw'?i*n *daw'?a*n
+    juz'?u*n  juz'?i*n  juz'?a*n
+    mabda'?u*n mabda'?i*n mabda'?a*n
+    naba'a q_ari'?u*n tak_afu'?u*n tak_afu'?i*n tak_afu'?a*n
+    abn_a'u abn_a'i abn_a'a jar_i'?u*n maqr_u'?u*n *daw'?u*n ^say'?u*n juz'?u*n
+    `ulam_a'u al-`ulam_a'i al-`ulam_a'a
+    `Amr?u*n*w wa-fa`al_u*a
+    """
+    ##
+    ###print(arabicToBetaCode(testStringArabic))
+    ar = betacodeToArabic(testBetaCode)
+    print(ar)
+    tl = betacodeToTranslit(testBetaCode)
+    print(tl)
+    loc = betacodeToLOC(testBetaCode)
+    print(loc)
+    bc = arabicToBetaCode(ar)
+    print(bc)
+    testtext = "_amḥān iimm_u?n ?bubur?os"
+    testtext = betacodeToArabic(testtext, paleo=True)
+    print(testtext)
+    #testtext = "امن آمں ٮُبُرْس"
+    testtext = arabicToBetaCode(testtext, paleo=True)
+    print(testtext)
+    testtext = betacodeToArabic(testtext, paleo=True)
+    print(testtext)
+    persiantest = "الکافي في الياسين"
+    pb = arabicToBetaCode(persiantest, paleo=True, persian=True)
+    print(pb)

--- a/betaCodeTables.py
+++ b/betaCodeTables.py
@@ -290,6 +290,7 @@ arabicBetaCode = {
     " ف " :  "f",   # fā’
     " ق " :  "q",   # qāf
     " ك " :  "k",   # kāf
+    " ک " :  "k",   # kāf / Persian
     " گ " :  "g",   # gāf / Persian
     " ل " :  "l",   # lām
     " م " :  "m",   # mīm
@@ -297,6 +298,7 @@ arabicBetaCode = {
     " ه " :  "h",   # hāʾ
     " و " :  "w",   # wāw
     " ي " :  "y",   # yāʾ
+    " ی " :  "y",   # yāʾ / Persian
 # Non-alphabetic letters
     " ء " :  "'",   # hamza
     " ئ " :  "'i",  # hamza

--- a/betaCodeTables.py
+++ b/betaCodeTables.py
@@ -128,9 +128,9 @@ translitLOC = {
     'a' : 'a',  # fatḥaŧ
     'u' : 'u',  # ḍammaŧ
     'i' : 'i',  # kasraŧ
-    'aȵ' : 'an',  # tanwīn fatḥ
-    'uȵ' : '',  # tanwīn ḍamm
-    'iȵ' : '',  # tanwīn kasr
+    'ảȵ' : 'an',  # tanwīn fatḥ
+    'ủȵ' : '',  # tanwīn ḍamm
+    'ỉȵ' : '',  # tanwīn kasr
     'ů' : '',  # silent w, like in `Amru.n.w
     'å' : '',  # silent alif, like in fa`al_u.a
     'ả' : '',  # final fatḥaŧ
@@ -185,14 +185,14 @@ translitSearch = {
     'a' : 'a',  # fatḥaŧ
     'u' : 'u',  # ḍammaŧ
     'i' : 'i',  # kasraŧ
-    'aȵ' : 'an',  # tanwīn fatḥ
-    'uȵ' : '',  # tanwīn ḍamm
-    'iȵ' : '',  # tanwīn kasr
+    'ảȵ' : 'an',  # tanwīn fatḥ
+    'ủȵ' : '',  # tanwīn ḍamm
+    'ỉȵ' : '',  # tanwīn kasr
     'ů' : '',   # silent w, like in `Amru.n.w
     'å' : '',   # silent alif, like in fa`al_u.a
     'ả' : '',   # final fatḥaŧ
-    'ỉ' : '',   # final ḍammaŧ
-    'ủ' : '',   # final kasraŧ
+    'ỉ' : '',   # final kasraŧ
+    'ủ' : '',   # final ḍammaŧ
     '°' : '',   # explicit sukūn
     }
 
@@ -242,14 +242,14 @@ translitArabic = {
     'a'  : ' َ ',  # fatḥaŧ
     'u'  : ' ُ ',  # ḍammaŧ
     'i'  : ' ِ ',  # kasraŧ
-    'aȵ' : ' ً ',  # tanwīn fatḥ
-    'uȵ' : ' ٌ ',  # tanwīn ḍamm
-    'iȵ' : ' ٍ ',  # tanwīn kasr
+    'ảȵ' : ' ً ',  # tanwīn fatḥ
+    'ủȵ' : ' ٌ ',  # tanwīn ḍamm
+    'ỉȵ' : ' ٍ ',  # tanwīn kasr
     'ů' : ' و ',  # silent w, like in `Amru.n.w
     'å' : ' ا ',  # silent alif, like in fa`al_u.a
     'ả' : ' َ ',  # final fatḥaŧ
-    'ỉ' : ' ِ ',  # final ḍammaŧ
-    'ủ' : ' ُ ',  # final kasraŧ
+    'ỉ' : ' ِ ',  # final kasraŧ
+    'ủ' : ' ُ ',  # final ḍammaŧ
 # Paleo: explicit sukūn
     '°' : ' ْ ',  # explicit sukūn
 # Paleo: Dotless letters
@@ -309,9 +309,9 @@ arabicBetaCode = {
     " َ " :  "a",   # fatḥaŧ
     " ُ " :  "u",   # ḍammaŧ
     " ِ " :  "i",   # kasraŧ
-    " ً " :  "a*n", # tanwīn fatḥ
-    " ٌ " :  "u*n", # tanwīn ḍamm
-    " ٍ " :  "i*n", # tanwīn kasr
+    " ً " :  "?a*n", # tanwīn fatḥ
+    " ٌ " :  "?u*n", # tanwīn ḍamm
+    " ٍ " :  "?i*n", # tanwīn kasr
 # Paleo: Dotless letters
     " ٮ" :  "?b",   # dotless b/t/th and non-final nūn/yāʾ
     " ٯ" :  "?q",   # dotless qāf

--- a/betaCodeTables.py
+++ b/betaCodeTables.py
@@ -13,6 +13,7 @@ betacodeTranslit = {
 # Alphabet letters
     '_a' : 'ā', # alif
     'b'  : 'b', # bā’
+    'p'  : 'p', # pe / Persian
     't'  : 't', # tā’
     '_t' : 'ṯ', # thā’
     '^g' : 'ǧ', # jīm
@@ -25,6 +26,7 @@ betacodeTranslit = {
     '_d' : 'ḏ', # dhāl
     'r'  : 'r', # rā’
     'z'  : 'z', # zayn
+    '^z' : 'ž', # že / Persian
     's'  : 's', # sīn
     '^s' : 'š', # shīn
     '*s' : 'ṣ', # ṣād
@@ -42,7 +44,7 @@ betacodeTranslit = {
     '*k' : 'ḳ', # qāf
     #'.k' : 'ḳ', # qāf
     'q'  : 'ḳ', # qāf
-    'k'  : 'k', # kāf
+    'k'  : 'k', # kāf (Arabic and Persian)
     'g'  : 'g', # gāf / Persian
     'l'  : 'l', # lām
     'm'  : 'm', # mīm
@@ -50,12 +52,12 @@ betacodeTranslit = {
     'h'  : 'h', # hā’
     'w'  : 'w', # wāw
     '_u' : 'ū', # wāw
-    'y'  : 'y', # yā’
-    '_i' : 'ī', # yā’
+    'y'  : 'y', # yā’ (Arabic and Persian)
+    '_i' : 'ī', # yā’ (Arabic and Persian)
 # Non-alphabetic letters
     '\'' : 'ʾ', # hamzaŧ
     '/a' : 'á', # alif maqṣūraŧ
-    #':t' : 'ŧ', # tā’ marbūṭaŧ, add +, it in idafa (`_amma:t+ ba*gd_ad)
+    #':t' : 'ŧ', # tā’ marbūṭaŧ, add +, if in idafa (`_amma:t+ ba*gd_ad)
     '=t' : 'ŧ', # tā’ marbūṭaŧ, this is preferable for Alpheios
 # Vowels
     '~a' : 'ã', # dagger alif
@@ -70,7 +72,9 @@ betacodeTranslit = {
     #'_n' : 'ȵ',  # n of tanwīn
     '*n' : 'ȵ',   # n of tanwīn
     '*w' : 'ů',  # silent w, like in `Amru.n.w
-    '*a' : 'å',  # silent alif, like in fa`al_u.a    
+    '*a' : 'å',  # silent alif, like in fa`al_u.a
+# Paleo: explicit sukūn
+    '!o' : '°',  # explicit sukūn
 # Paleo: Dotless letters
     "?b" :  "ɓ",   # dotless b/t/th and non-final nūn/yāʾ
     "?q" :  "ɋ",   # dotless qāf
@@ -83,6 +87,7 @@ translitLOC = {
 # Alphabet letters
     'ā' : 'ā',  # alif
     'b' : 'b',  # bā’
+    'p' : 'p',  # pe / Persian
     't' : 't',  # tā’
     'ṯ' : 'th', # thā’
     'ǧ' : 'j',  # jīm
@@ -93,6 +98,7 @@ translitLOC = {
     'ḏ' : 'dh', # dhāl
     'r' : 'r',  # rā’
     'z' : 'z',  # zayn
+    'ž' : 'zh', # zhe / Persian
     's' : 's',  # sīn
     'š' : 'sh', # shīn
     'ṣ' : 'ṣ',  # ṣād
@@ -114,7 +120,7 @@ translitLOC = {
     'y' : 'y',  # yā’
     'ī' : 'ī',  # yā’
 # Non-alphabetic letters
-    'ʾ' : 'ʾ',   # hamzaŧ
+    'ʾ' : 'ʾ',  # hamzaŧ
     'á' : 'ā',  # alif maqṣūraŧ
     'ŧ' : 'h',  # tā’ marbūṭaŧ
 # Vowels
@@ -129,7 +135,8 @@ translitLOC = {
     'å' : '',  # silent alif, like in fa`al_u.a
     'ả' : '',  # final fatḥaŧ
     'ỉ' : '',  # final ḍammaŧ
-    'ủ' : '',  # final kasraŧ    
+    'ủ' : '',  # final kasraŧ
+    '°' : '',  # explicit sukūn
     }
 
 # necessary for rendering searcheable lines
@@ -137,6 +144,7 @@ translitSearch = {
 # Alphabet letters
     'ā' : 'a',  # alif
     'b' : 'b',  # bā’
+    'p' : 'p',  # pe / Persian
     't' : 't',  # tā’
     'ṯ' : 'th', # thā’
     'ǧ' : 'j',  # jīm
@@ -147,6 +155,7 @@ translitSearch = {
     'ḏ' : 'dh', # dhāl
     'r' : 'r',  # rā’
     'z' : 'z',  # zayn
+    'ž' : 'zh', # zhe / Persian
     's' : 's',  # sīn
     'š' : 'sh', # shīn
     'ṣ' : 's',  # ṣād
@@ -179,37 +188,41 @@ translitSearch = {
     'aȵ' : 'an',  # tanwīn fatḥ
     'uȵ' : '',  # tanwīn ḍamm
     'iȵ' : '',  # tanwīn kasr
-    'ů' : '',  # silent w, like in `Amru.n.w
-    'å' : '',  # silent alif, like in fa`al_u.a
-    'ả' : '',  # final fatḥaŧ
-    'ỉ' : '',  # final ḍammaŧ
-    'ủ' : '',  # final kasraŧ 
+    'ů' : '',   # silent w, like in `Amru.n.w
+    'å' : '',   # silent alif, like in fa`al_u.a
+    'ả' : '',   # final fatḥaŧ
+    'ỉ' : '',   # final ḍammaŧ
+    'ủ' : '',   # final kasraŧ
+    '°' : '',   # explicit sukūn
     }
 
 translitArabic = {
 # Alphabet letters
     'ā' : ' ا ',  # alif
     'b' : ' ب ',  # bāʾ
+    'p' : ' پ ',  # pe / Persian
     't' : ' ت ',  # tāʾ
-    'ṯ' : ' ث ', # thāʾ
+    'ṯ' : ' ث ',  # thāʾ
     'ǧ' : ' ج ',  # jīm
-    'č' : ' چ ', # chīm / Persian
+    'č' : ' چ ',  # chīm / Persian
     'ḥ' : ' ح ',  # ḥāʾ
-    'ḫ' : ' خ ', # khāʾ
+    'ḫ' : ' خ ',  # khāʾ
     'd' : ' د ',  # dāl
-    'ḏ' : ' ذ ', # dhāl
+    'ḏ' : ' ذ ',  # dhāl
     'r' : ' ر ',  # rāʾ
     'z' : ' ز ',  # zayn
+    'ž' : ' ژ ',  # zhe / Persian
     's' : ' س ',  # sīn
-    'š' : ' ش ', # shīn
+    'š' : ' ش ',  # shīn
     'ṣ' : ' ص ',  # ṣād
     'ḍ' : ' ض ',  # ḍād
     'ṭ' : ' ط ',  # ṭāʾ
     'ẓ' : ' ظ ',  # ẓāʾ
     'ʿ' : ' ع ',  # ʿayn
-    'ġ' : ' غ ', # ghayn
+    'ġ' : ' غ ',  # ghayn
     'f' : ' ف ',  # fā’
     'ḳ' : ' ق ',  # qāf
+    'q' : ' ق ',  # qāf
     'k' : ' ك ',  # kāf
     'g' : ' گ ',  # gāf / Persian
     'l' : ' ل ',  # lām
@@ -249,19 +262,23 @@ translitArabic = {
 arabicBetaCode = {
 # Alphabet letters
     " ا " :  "_a",   # alif
-    " أ " :  "'a",   # alif
-    " إ " :  "'i",   # alif
-    " آ " :  "'_a",  # alif
+    " أ " :  "'a",   # alif with hamza on top
+    " إ " :  "'i",   # alif alif with hamza beneath
+    " آ " :  "'_a",  # alif + madda
+    #" ٱ " : "???",   # alif + waṣla
     " ب " :  "b",   # bāʾ
+    " پ " :  "p",   # pe / Persian
     " ت " :  "t",   # tāʾ
     " ث " :  "_t",  # thāʾ
     " ج " :  "^g",  # jīm
+    " چ " :  "^c",  # chīm / Persian
     " ح " :  "*h",  # ḥāʾ
     " خ " :  "_h",  # khāʾ
     " د " :  "d",   # dāl
     " ذ " :  "_d",  # dhāl
     " ر " :  "r",   # rāʾ
     " ز " :  "z",   # zayn
+    " ژ " :  "^z",  # zhe / Persian
     " س " :  "s",   # sīn
     " ش " :  "^s",  # shīn
     " ص " :  "*s",  # ṣād
@@ -273,6 +290,7 @@ arabicBetaCode = {
     " ف " :  "f",   # fā’
     " ق " :  "q",   # qāf
     " ك " :  "k",   # kāf
+    " گ " :  "g",   # gāf / Persian
     " ل " :  "l",   # lām
     " م " :  "m",   # mīm
     " ن " :  "n",   # nūn
@@ -281,7 +299,7 @@ arabicBetaCode = {
     " ي " :  "y",   # yāʾ
 # Non-alphabetic letters
     " ء " :  "'",   # hamza
-    " ئ " :  "'i",   # hamza
+    " ئ " :  "'i",  # hamza
     " ؤ " :  "'u",  # hamza
     " ى " :  "/a",  # alif maqṣūraŧ
     " ة " :  "=t",  # tāʾ marbūṭaŧ
@@ -299,4 +317,6 @@ arabicBetaCode = {
     " ٯ" :  "?q",   # dotless qāf
     " ں" :  "?n",   # dotless final nūn
     " ڡ" :  "?f",   # dotless fāʾ
+# Paleo: explicit sukūn
+    " ْ " :  "!o",   # explicit sukūn
     }


### PR DESCRIPTION
I added support for transcription of Persian letters; I added all Persian letters (chīm and gāf were already there) to the dictionaries, and made a new optional argument `persian` (default: `False`) for both ToArabic functions that, if True, outputs the Persian versions of *kāf*s and *yeh*s. 
In addition, I also changed the examples in the README file to agree with the rule changes Maxim made because of Alpheios (=t instead of :t, and \*s etc instead of .s etc). 
Finally, I adapted the tanwīn rules in the code to agree with the rules outlined in the README file (the original code still had u\*n etc. instead of ?u\*n  etc.)